### PR TITLE
only use the authentication identity files configured in ssh_config

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,6 +103,8 @@ func main() {
 		"UserKnownHostsFile=/dev/null",
 		"-o",
 		"StrictHostKeyChecking=no",
+		"-o",
+		"IdentitiesOnly=yes",
 		fmt.Sprintf("root@%s", *taskIP), // <- TODO: support different user
 	)
 	// redirect the output to terminal


### PR DESCRIPTION
## What this PR does
Fixes issue `Too many authentication failures`. This issue only shows up if the client ssh's into many remote servers (the intended usecase for this project). 


## Explanation for the bug
This happens because the ssh client tries all the ssh keys known by the ssh-agent and all other keys, when attempting to connect to the remote server. This is the default behavior of ssh.

Since ssh server (sshd) on the remote server expects a particular identity key, the server rejects the connection and ssh client aborts with the above error.

I stole this explanation from [here](https://www.tecmint.com/fix-ssh-too-many-authentication-failures-error/) but I tested it and it works